### PR TITLE
Add quotes to Org and Space on cf login commands.

### DIFF
--- a/blue-green-app-deployment/ci/tasks/current-app-get-info
+++ b/blue-green-app-deployment/ci/tasks/current-app-get-info
@@ -7,7 +7,7 @@ env
 
 cf api $PWS_API --skip-ssl-validation
 
-cf login -u $PWS_USER -p $PWS_PWD -o $PWS_ORG -s $PWS_SPACE
+cf login -u $PWS_USER -p $PWS_PWD -o "$PWS_ORG" -s "$PWS_SPACE"
 
 cf apps
 

--- a/blue-green-app-deployment/ci/tasks/update-routes
+++ b/blue-green-app-deployment/ci/tasks/update-routes
@@ -7,7 +7,7 @@ env
 
 cf api $PWS_API --skip-ssl-validation
 
-cf login -u $PWS_USER -p $PWS_PWD -o $PWS_ORG -s $PWS_SPACE
+cf login -u $PWS_USER -p $PWS_PWD -o "$PWS_ORG" -s "$PWS_SPACE"
 
 cf apps
 


### PR DESCRIPTION
This PR simply adds quotes to `cf login` commands to avoid errors when organization and space names have spaces in them.
