### PR TITLE
For PKS 1.0.3 pks_params.yml has invalid property for GCP key

### DIFF
--- a/pipelines/pcf/pks/install-pks/pks_params.yml
+++ b/pipelines/pcf/pks/install-pks/pks_params.yml
@@ -152,6 +152,11 @@ properties: |
     value: ((gcp_vpc_network))  # Specify the VPC network name that will be used by the Kubernetes Cloud Provider
   .properties.cloud_provider.gcp.service_key:
     value: ((gcp_service_key))
+  ## For PKS 1.0.3+ uncomment and use below two keys instead of .properties.cloud_provider.gcp.service_key
+    #.properties.cloud_provider.gcp.master_service_account_key:
+    #value: ((gcp_service_key))
+    #.properties.cloud_provider.gcp.worker_service_account_key:
+    #value: ((gcp_service_key))
 
   ### if VSPHERE is to be selected, then uncomment and fill out the VSPHERE parameters below
   ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors


### PR DESCRIPTION
- "properties.cloud_provider.gcp.service_key" is not a valid key in PKS 1.0.3
- Added new required keys to support PKS 1.0.3
"properties.cloud_provider.gcp.master_service_account_key"
"properties.cloud_provider.gcp.worker_service_account_key"

Authored-by: Goutam Tadi <gtadi@pivotal.io>