### PR TITLE
Clarifies pks params when using vsphere

### DIFF
--- a/pipelines/pcf/pks/install-pks/pipeline.yml
+++ b/pipelines/pcf/pks/install-pks/pipeline.yml
@@ -182,14 +182,15 @@ jobs:
       trigger: true
       params:
         globs: []
-  - task: apply-changes
-    file: pcf-pipelines-utils/tasks/pcf/apply-changes/task.yml
+  - task: apply-changes-single-product
+    file: pcf-pipelines-utils/tasks/pcf/apply-changes-single-product/task.yml
     params:
       OPSMAN_CLIENT_ID: {{opsman_client_id}}
       OPSMAN_CLIENT_SECRET: {{opsman_client_secret}}
       OPSMAN_DOMAIN_OR_IP_ADDRESS: {{opsman_domain}}
       OPSMAN_PASSWORD: {{opsman_admin_password}}
       OPSMAN_USERNAME: {{opsman_admin_username}}
+      PRODUCT_NAME: {{product_name}}
 
 - name: create-pks-cli-user
   plan:

--- a/pipelines/pcf/pks/install-pks/pks_params.yml
+++ b/pipelines/pcf/pks/install-pks/pks_params.yml
@@ -165,15 +165,15 @@ properties: |
   ### if GCP is to be selected, then uncomment and fill out the GCP parameters below.
   ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
   .properties.cloud_provider.gcp.project_id:
-    value: ((gcp_project_id))
+    value: ( (gcp_project_id) )
   .properties.cloud_provider.gcp.network:
-    value: ((gcp_vpc_network))  # Specify the VPC network name that will be used by the Kubernetes Cloud Provider
+    value: ( (gcp_vpc_network) )  # Specify the VPC network name that will be used by the Kubernetes Cloud Provider
   .properties.cloud_provider.gcp.master_service_account:
-    value: ((gcp_master_service_account))   # A service account used by kubernetes to configure load balancers, persistent volumes, firewalls, vms, etc. on behalf of the kubernetes master.
+    value: ( (gcp_master_service_account) )   # A service account used by kubernetes to configure load balancers, persistent volumes, firewalls, vms, etc. on behalf of the kubernetes master.
   .properties.cloud_provider.gcp.worker_service_account:
-    value: ((gcp_worker_service_account))  # A service account used by kubernetes workers. This account should have fewer permissions than the master.
+    value: ( (gcp_worker_service_account) )  # A service account used by kubernetes workers. This account should have fewer permissions than the master.
 
-  ### if VSPHERE is to be selected, then uncomment and fill out the VSPHERE parameters below
+  ### if vSphere is to be selected, then uncomment and fill out the vSphere parameters below
   ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
   # .properties.cloud_provider.vsphere.vcenter_master_creds:
   #   value:

--- a/tasks/pcf/apply-changes-single-product/task.sh
+++ b/tasks/pcf/apply-changes-single-product/task.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+echo "Applying changes to ${PRODUCT_NAME} on Ops Manager @ ${OPSMAN_DOMAIN_OR_IP_ADDRESS}"
+
+om-linux version
+
+# Current version of om-linux available on the image-resourece does not have the om version with selective deploy.
+# This is a hack to pull down the latest version
+curl -sSL -o om-linux $(curl -s https://api.github.com/repos/pivotal-cf/om/releases/latest | jq -r -c ".assets[] | .browser_download_url" | grep linux) && chmod +x om-linux
+./om-linux version
+
+./om-linux \
+  --target "https://${OPSMAN_DOMAIN_OR_IP_ADDRESS}" \
+  --skip-ssl-validation \
+  --client-id "${OPSMAN_CLIENT_ID}" \
+  --client-secret "${OPSMAN_CLIENT_SECRET}" \
+  --username "${OPSMAN_USERNAME}" \
+  --password "${OPSMAN_PASSWORD}" \
+  apply-changes \
+  --product-name "${PRODUCT_NAME}" \
+  --ignore-warnings

--- a/tasks/pcf/apply-changes-single-product/task.yml
+++ b/tasks/pcf/apply-changes-single-product/task.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pcfnorm/rootfs
+    version: release-candidate
+
+inputs:
+  - name: pcf-pipelines-utils
+
+params:
+  OPSMAN_CLIENT_ID:
+  OPSMAN_CLIENT_SECRET:
+  OPSMAN_USERNAME:
+  OPSMAN_PASSWORD:
+  OPSMAN_DOMAIN_OR_IP_ADDRESS:
+  PRODUCT_NAME:
+
+run:
+  path: pcf-pipelines-utils/tasks/pcf/apply-changes-single-product/task.sh

--- a/tasks/pcf/pks/delete-pks-cluster/task.sh
+++ b/tasks/pcf/pks/delete-pks-cluster/task.sh
@@ -5,7 +5,7 @@ pks login -a "$PCF_PKS_API" -u "$PKS_CLI_USERNAME" -p "$PKS_CLI_PASSWORD" --skip
 pks cluster "$PKS_CLUSTER_NAME"
 
 echo "Deleting PKS cluster [$PKS_CLUSTER_NAME]..."
-pks delete-cluster "$PKS_CLUSTER_NAME"
+pks delete-cluster "$PKS_CLUSTER_NAME" --non-interactive
 
 echo "Monitoring the deletion status for PKS cluster [$PKS_CLUSTER_NAME]"
 in_progress_state="in progress"


### PR DESCRIPTION
Added spaces to the gcp parameters, because when I commented the lines due to vSphere IaaS, fly complained because I did not supply the parameters.  Also changed casing on VPSHERE because while troubleshooting the former challenge, I was led astray thinking that I didn't not have proper casing for vSphere.