### PR TITLE
 fix for PKS 1.2 error "release not found for version:" Ubuntu Xenial

### DIFF
--- a/pipelines/pcf/pks/install-pks/pks_params_1.2.yml
+++ b/pipelines/pcf/pks/install-pks/pks_params_1.2.yml
@@ -1,0 +1,360 @@
+######## PKS tile-specific parameters
+product_name: pivotal-container-service  # do not change
+product_version: ^1\.1\..*$  # PKS tile version to install
+
+# Note: check companion "pks_vault_params.sh" script for automated credentials
+#       creation for this pipeline in either Vault or CredHub.
+
+# base domain for PKS - # e.g. pks.mydomain.com
+pcf_pks_domain: ((pcf_pks_domain))
+# domain for PKS API - # e.g. api.pks.mydomain.com
+pcf_pks_api_domain: ((pcf_pks_api_domain))
+
+# PKS CLI client ID to be created (if applicable) by post-deploy job "create-pks-cli-user"
+pks_cli_username: ((pks_cli_username))  # username to be created in PKS UAA
+pks_cli_password: ((pks_cli_password))  # password for PKS user to be created
+pks_cli_useremail: pksadmin@example.com # email address for PKS user to be created
+
+
+######## AZs and Networks configuration for the tile
+networks: |
+  network:
+    name: ((services_network_name))
+  other_availability_zones:
+  - name: ((az_1_name))
+  - name: ((az_2_name))
+  - name: ((az_3_name))
+  service_network:
+    name: ((dynamic_services_network_name))
+  singleton_availability_zone:
+    name: ((az_1_name))
+
+
+properties: |
+
+  ######## Certificate to secure the PKS API
+  .pivotal-container-service.pks_tls:
+    #
+    # The "generate_cert_domains" parameter controls the automatic certificates
+    #   generation behavior for this property.
+    #
+    # If auto-generation of certs is desired, leave this parameter un-commented
+    #   and update the array of domain names to be used for cert generation.
+    #   e.g. ["*.pks.mydomain.com","*.api.pks.mydomain.com"].
+    #   Leave parameters cert_pem and private_key_pem with empty values in this case.
+    #
+    # Otherwise, either comment out or delete this parameter line and
+    #   provide the certificate (cert_pem) and private key (private_key_pem) values
+    #   in the corresponding parameters further below.
+    #
+    generate_cert_domains: ["*.((pcf_pks_domain))","*.((pcf_pks_api_domain))"]
+    value:
+      cert_pem:
+      private_key_pem:
+  ## API Hostname (FQDN)
+  .properties.pks_api_hostname:
+    value: ((pcf_pks_api_domain))
+
+  ######## Configuration for Plan 1
+  .properties.plan1_selector:
+    value: "Plan Active"
+  .properties.plan1_selector.active.name:
+    value: "small"  # the name that appears for end users to choose
+  .properties.plan1_selector.active.description:
+    value: "Small plan"
+  .properties.plan1_selector.active.master_az_placement:
+    value: [((az_1_name))]  # Specify the availability zones you want your master and ETCD nodes spread across equally. If only one master/ETCD has been selected, choose a single AZ for your singleton job.
+  .properties.plan1_selector.active.worker_az_placement:
+    value: [((az_1_name)),((az_2_name)),((az_3_name))]  # Specify the availability zones you want your worker nodes spread across equally.
+  .properties.plan1_selector.active.master_instances:
+    value: 1
+  .properties.plan1_selector.active.master_vm_type:
+    value: medium
+  .properties.plan1_selector.active.master_persistent_disk_type:
+    value: "10240"
+  .properties.plan1_selector.active.worker_vm_type:
+    value: medium
+  .properties.plan1_selector.active.worker_persistent_disk_type:
+    value: "10240"
+  .properties.plan1_selector.active.worker_instances:
+    value: 3    # The number of K8s worker instances
+  .properties.plan1_selector.active.errand_vm_type:
+    value: micro
+  .properties.plan1_selector.active.addons_spec:
+    value: "" # Kubernetes yml that contains specifications of addons to run on every cluster. This is an experimental feature. Please consider carefully before applying this to your plan
+  .properties.plan1_selector.active.allow_privileged_containers:
+    value: false  # Privileged containers run with host-like permissions. Allowing your users to deploy privileged containers in clusters using this plan can create security vulnerabilities and may impact other tiles. Use with caution.
+  .properties.plan1_selector.active.disable_deny_escalating_exec:
+    value: false  # This admission controller will deny exec and attach commands to pods that run with escalated privileges that allow host access. If checked, the admission controller will be disabled. Clusters in this plan can then create security vulnerabilities and may impact other tiles. Use with caution.
+
+
+  ######## Configuration for Plan 2 - "Plan Inactive" or "Plan Active"
+  .properties.plan2_selector:
+    value: "Plan Inactive"
+  ### if plan 2 is to be activated, then uncomment and fill out the plan2 parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.plan2_selector.active.name:
+  #   value: "medium"  # the name that appears for end users to choose
+  # .properties.plan2_selector.active.description:
+  #   value: "Plan 2 description"
+  # .properties.plan2_selector.active.master_az_placement:
+  #   value: [( ( az_1_name ) )]  # Specify the AZ in which the cluster will be created
+  # .properties.plan2_selector.active.worker_az_placement:
+  #   value: [( ( az_1_name ) ),( ( az_2_name ) ),( ( az_3_name ) )]  # Specify the availability zones you want your worker nodes spread across equally.
+  # .properties.plan2_selector.active.master_instances:
+  #   value: 3
+  # .properties.plan2_selector.active.master_vm_type:
+  #   value: large
+  # .properties.plan2_selector.active.master_persistent_disk_type:
+  #   value: "10240"
+  # .properties.plan2_selector.active.worker_vm_type:
+  #   value: medium
+  # .properties.plan2_selector.active.worker_persistent_disk_type:
+  #   value: "10240"
+  # .properties.plan2_selector.active.worker_instances:
+  #   value: 5    # The number of K8s worker instances
+  # .properties.plan2_selector.active.errand_vm_type:
+  #   value: micro
+  # .properties.plan2_selector.active.addons_spec:
+  #   value: "" # Kubernetes yml that contains specifications of addons to run on every cluster. This is an experimental feature. Please consider carefully before applying this to your plan
+  # .properties.plan2_selector.active.allow_privileged_containers:
+  #   value: false  # Privileged containers run with host-like permissions. Allowing your users to deploy privileged containers in clusters using this plan can create security vulnerabilities and may impact other tiles. Use with caution.
+  # .properties.plan2_selector.active.disable_deny_escalating_exec:
+  #   value: false  # This admission controller will deny exec and attach commands to pods that run with escalated privileges that allow host access. If checked, the admission controller will be disabled. Clusters in this plan can then create security vulnerabilities and may impact other tiles. Use with caution.
+
+
+  ######## Configuration for Plan 3 - "Plan Inactive" or "Plan Active"
+  .properties.plan3_selector:
+    value: "Plan Inactive"
+  ### if plan 3 is to be activated, then uncomment and fill out the plan3 parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.plan3_selector.active.name:
+  #   value: "large"  # the name that appears for end users to choose
+  # .properties.plan3_selector.active.description:
+  #   value: "Plan 3 description"
+  # .properties.plan3_selector.active.master_az_placement:
+  #   value: [( ( az_1_name ) )]  # Specify the AZ in which the cluster will be created
+  # .properties.plan3_selector.active.worker_az_placement:
+  #   value: [( ( az_1_name ) ),( ( az_2_name ) ),( ( az_3_name ) )]  # Specify the availability zones you want your worker nodes spread across equally.
+  # .properties.plan3_selector.active.master_instances:
+  #   value: 3
+  # .properties.plan3_selector.active.master_vm_type:
+  #   value: large
+  # .properties.plan3_selector.active.master_persistent_disk_type:
+  #   value: "10240"
+  # .properties.plan3_selector.active.worker_vm_type:
+  #   value: large
+  # .properties.plan3_selector.active.worker_persistent_disk_type:
+  #   value: "10240"
+  # .properties.plan3_selector.active.worker_instances:
+  #   value: 8    # The number of K8s worker instances
+  # .properties.plan3_selector.active.errand_vm_type:
+  #   value: micro
+  # .properties.plan3_selector.active.addons_spec:
+  #   value: "" # Kubernetes yml that contains specifications of addons to run on every cluster. This is an experimental feature. Please consider carefully before applying this to your plan
+  # .properties.plan3_selector.active.allow_privileged_containers:
+  #   value: false  # Privileged containers run with host-like permissions. Allowing your users to deploy privileged containers in clusters using this plan can create security vulnerabilities and may impact other tiles. Use with caution.
+  # .properties.plan3_selector.active.disable_deny_escalating_exec:
+  #   value: false  # This admission controller will deny exec and attach commands to pods that run with escalated privileges that allow host access. If checked, the admission controller will be disabled. Clusters in this plan can then create security vulnerabilities and may impact other tiles. Use with caution.
+
+
+  ######## Kubernetes cloud provider: GCP or vSphere, or AWS
+  .properties.cloud_provider:
+    value: GCP
+
+  ### if GCP is to be selected, then uncomment and fill out the GCP parameters below.
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  .properties.cloud_provider.gcp.project_id:
+    value: ((gcp_project_id))
+  .properties.cloud_provider.gcp.network:
+    value: ((gcp_vpc_network))  # Specify the VPC network name that will be used by the Kubernetes Cloud Provider
+  .properties.cloud_provider.gcp.master_service_account:
+    value: ((gcp_master_service_account))   # A service account used by kubernetes to configure load balancers, persistent volumes, firewalls, vms, etc. on behalf of the kubernetes master.
+  .properties.cloud_provider.gcp.worker_service_account:
+    value: ((gcp_worker_service_account))  # A service account used by kubernetes workers. This account should have fewer permissions than the master.
+
+  ### if VSPHERE is to be selected, then uncomment and fill out the VSPHERE parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.cloud_provider.vsphere.vcenter_master_creds:
+  #   value:
+  #     identity: ( ( vcenter_username ) ) # vcenter_admin_username
+  #     password: ( ( vcenter_password ) ) # vcenter_admin_password
+  # .properties.cloud_provider.vsphere.vcenter_ip:
+  #   value: ( ( vcenter_host ) )
+  # .properties.cloud_provider.vsphere.vcenter_dc:
+  #   value: ( ( vcenter_datacenter ) )
+  # .properties.cloud_provider.vsphere.vcenter_ds:
+  #   value: ( ( vcenter_datastore ) )
+  # .properties.cloud_provider.vsphere.vcenter_vms:
+  #   value: ( ( vcenter_pcf_folder ) ) # The name should be the same as the VM Folder in the Ops Manager Director tile, under the vCenter config page.
+
+  ### if AWS is selected, then uncomment and fill out the AWS parameters below.
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  #  .properties.cloud_provider.aws.iam_instance_profile.master:
+  #     value: 
+  #   .properties.cloud_provider.aws.iam_instance_profile.worker:
+  #     value: 
+
+  ######## Network selector - flannel or nsx
+  .properties.network_selector:
+    value: flannel
+  ### if NSX-T is to be used, then uncomment and fill out the nxt parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.network_selector.nsx.nsx-t-host:
+  #   value: ( ( nsxt_hostname_or_ipaddress ) )  # Please enter the NSX Manager hostname or IP address
+  # .properties.network_selector.nsx.credentials:
+  #   value:
+  #     identity: ( ( nsxt_admin_username ) )  # username to connect to the NSX Manager
+  #     password: ( ( nsxt_admin_password ) )  # password to connect to the NSX Manager
+  # .properties.network_selector.nsx.nsx-t-ca-cert:
+  #   value: |  # Optional custom CA certificate to be used to connect to NSX Manager
+  #     -----BEGIN CERTIFICATE-----
+  #     ...
+  #     -----END CERTIFICATE-----
+  # .properties.network_selector.nsx.vcenter_cluster:
+  #   value: ( ( nsxt_vcenter_cluster ) )   # Please enter the vSphere cluster name where PKS will be deployed
+  # .properties.network_selector.nsx.nsx-t-insecure:
+  #   value: false    # whether to disable SSL certificate verification when connecting to the NSX Manager
+  # .properties.network_selector.nsx.t0-router-id:
+  #   value: ( ( nsxt_t0_routerid ) )  # the UUID of the Tier-0 logical router configured in NSX manager
+  # .properties.network_selector.nsx.ip-block-id:
+  #   value: ( ( nxst_ip_block_id ) )  # the UUID of the IP Block configured in NSX manager
+  # .properties.network_selector.nsx.floating-ip-pool-ids:
+  #   value: ( ( nsxt_floating_ip_pool_id ) )  # the UUID of the Floating IP Pool configured in NSX manager (for the current release only a single ID is supported)
+  # .properties.network_selector.nsx.network_automation:
+  #   value: true     # Automated Network Provisioning
+  # .properties.network_selector.nsx.nat_mode:
+  #   value: true
+  # .properties.network_selector.nsx.nodes-ip-block-id:
+  #   value:               # Nodes IP Block ID
+  # .properties.network_selector.nsx.bosh-client-id:
+  #   value:
+  # .properties.network_selector.nsx.bosh-client-secret:
+  #   value:
+  #     secret: "***"
+  # .properties.proxy_selector:
+  #   value: Disabled      # HTTP/HTTPS Proxy (for vSphere only) - Enabled or Disabled
+  # .properties.proxy_selector.enabled.http_proxy_url:
+  #   value:
+  # .properties.proxy_selector.enabled.http_proxy_credentials:
+  #   value:
+  #     password: "***"
+  # .properties.proxy_selector.enabled.no_proxy:
+  #   value:
+  # .properties.vm_extensions:
+  #   value:           # Allow outbound internet access from Kubernetes cluster vms (IaaS-dependent)
+  #   - public_ip      # Enable outbound internet access. Warning: Not allowing internet access will require a NAT instance.
+
+
+  ######## UAA configuration page
+  .properties.uaa_pks_cli_access_token_lifetime:
+    value: 86400
+  .properties.uaa_pks_cli_refresh_token_lifetime:
+    value: 172800
+
+  ## Configure your UAA user account store with either internal or external authentication mechanisms
+  ## Accepted values:
+  ## - internal    (Internal UAA)
+  ## - ldap        (LDAP Server)
+  .properties.uaa:
+    value: internal
+
+  ### if ldap server, then uncomment and fill out the ldap parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.uaa.ldap.url:
+  #   value:
+  # .properties.uaa.ldap.credentials:
+  #   value:
+  #     password: "***"
+  # .properties.uaa.ldap.search_base:
+  #   value:
+  # .properties.uaa.ldap.search_filter:
+  #   value: cn={0}
+  # .properties.uaa.ldap.group_search_base:
+  #   value:
+  # .properties.uaa.ldap.group_search_filter:
+  #   value: member={0}
+  # .properties.uaa.ldap.server_ssl_cert:
+  #   value:
+  # .properties.uaa.ldap.server_ssl_cert_alias:
+  #   value:
+  # .properties.uaa.ldap.mail_attribute_name:
+  #   value: mail
+  # .properties.uaa.ldap.email_domains:
+  #   value:
+  # .properties.uaa.ldap.first_name_attribute:
+  #   value:
+  # .properties.uaa.ldap.last_name_attribute:
+  #   value:
+  # .properties.uaa.ldap.ldap_referrals:
+  #   value: follow
+
+  ######## MONITORING
+  ## Wavefront Integration - enabled or disabled
+  .properties.wavefront:
+    value: disabled
+  ### if wavefront integration is enabled, uncomment and fill out the wavefront parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.wavefront.enabled.wavefront_api_url:
+  #   value:
+  # .properties.wavefront.enabled.wavefront_token:
+  #   value:
+  #     secret: "***"
+  # .properties.wavefront.enabled.wavefront_alert_targets:
+  #   value:
+
+  ######## LOGGING
+  ######## SYSLOG - disabled or enabled
+  .properties.syslog_selector:
+    value: disabled
+  ### if syslog is enabled, uncomment and fill out the syslog parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.syslog_migration_selector.enabled.address:
+  #   value: 10.10.10.10  #The address or host for the syslog server
+  # .properties.syslog_migration_selector.enabled.port:
+  #   value: 0  # The port on which the syslog server listens
+  # .properties.syslog_migration_selector.enabled.transport_protocol:
+  #   value: tcp  # The transport protocol used to send syslog messages to the server
+  # .properties.syslog_migration_selector.enabled.tls_enabled:
+  #   value: true # Send logs encrypted to syslog server via TLS
+  # .properties.syslog_migration_selector.enabled.permitted_peer:
+  #   value: "*.example.com" # Either the accepted fingerprint (SHA1) or name of remote peer
+  # .properties.syslog_migration_selector.enabled.ca_cert:
+  #   value: |
+  #     -----BEGIN CERTIFICATE-----
+  #     ...
+  #     -----END CERTIFICATE-----
+  ###
+  ### VMware vRealize Log Insight Integration - disabled or enabled
+  .properties.pks-vrli:
+    value: disabled
+  ### if vRealize Log Insight Integration is enabled, uncomment and fill out the corresponding parameters below
+  ### otherwise, leave this section commented out to avoid Ops Manager parameter settings errors
+  # .properties.pks-vrli.enabled.host:
+  #   value:
+  # .properties.pks-vrli.enabled.use_ssl:
+  #   value: true
+  # .properties.pks-vrli.enabled.skip_cert_verify:
+  #   value: false
+  # .properties.pks-vrli.enabled.ca_cert:
+  #   value:
+  # .properties.pks-vrli.enabled.rate_limit_msec:
+  #   value: 0
+  #
+
+  ######## TELEMETRY
+  ## Information about PKS configuration and usage can be collected to provide better support and product improvements: enabled or disabled
+  .properties.telemetry_selector:
+    value: disabled
+
+######## Errands to disable
+errands_to_disable: ""
+  # pks-nsx-t-precheck,upgrade-all-service-instances,delete-all-clusters
+
+######## Resources
+resources: |
+  pivotal-container-service:
+    instance_type:
+      id: micro
+    persistent_disk:
+      size_mb: "10240"

--- a/tasks/pcf/upload-product-and-stemcell/task.sh
+++ b/tasks/pcf/upload-product-and-stemcell/task.sh
@@ -51,6 +51,8 @@ if [ -n "$STEMCELL_VERSION" ]; then
         '
         if any(.Dependencies[]; select(.Release.Product.Name | contains("Stemcells for PCF (Windows)"))) then
           "stemcells-windows-server"
+        elif any(.Dependencies[]; select(.Release.Product.Name | contains("Stemcells for PCF (Ubuntu Xenial)"))) then
+          "stemcells-ubuntu-xenial"
         else
           "stemcells"
         end


### PR DESCRIPTION
hi,

here is a fix when you install PKS 1.2.x as follows error: "release not found for version:"
pks 1.2 release adopted new stamcell name and it needs to be applied to pipelines.

thanks. 