### PR TITLE
Update load-tests

### DIFF
--- a/pipelines/appdev/blue-green-app-deployment/ci/tasks/load-tests
+++ b/pipelines/appdev/blue-green-app-deployment/ci/tasks/load-tests
@@ -4,7 +4,7 @@ set -e
 
 echo "Installing artillery for load tests: https://artillery.io/docs/getting-started/"
 
-npm install -g artillery
+npm install -g artillery@"1.6.0-24"
 
 export NEXT_APP_COLOR=$(cat ./current-app-info/next-app.txt)
 export NEXT_APP_URL=http://$NEXT_APP_COLOR-$PWS_APP_SUFFIX.$PWS_APP_DOMAIN/


### PR DESCRIPTION
Artillery fails with newer versions, so binding to
npm install -g artillery@"1.6.0-24"